### PR TITLE
issue #13 Limit sat selection to active group

### DIFF
--- a/src/viewer/Satellites.ts
+++ b/src/viewer/Satellites.ts
@@ -105,7 +105,6 @@ class Satellites implements SceneComponent, SelectableSatellite {
       for (let i = 0; i < satellites.length; i++) {
         let color = this.currentColorScheme?.getSatelliteColor(satellites[i], this.satelliteGroup)?.color; // || [0, 0, 0];
         if (!color) {
-          console.log('no color', satellites[i].id);
           color = [0, 0, 0];
         }
         const idx = i * 4;
@@ -219,13 +218,17 @@ class Satellites implements SceneComponent, SelectableSatellite {
     }
   }
 
-  setSatelliteGroup (satelliteGroup: SatelliteGroup) {
+  setSatelliteGroup (satelliteGroup?: SatelliteGroup) {
     this.satelliteGroup = satelliteGroup;
     if (this.satelliteGroup) {
       this.currentColorScheme = new GroupColorScheme();
     } else {
       this.currentColorScheme = new DefaultColorScheme();
     }
+  }
+
+  getSatellitegroup (): SatelliteGroup | undefined {
+    return this.satelliteGroup;
   }
 
   setSelectedSatellites (satelliteIndexes: number[]) {


### PR DESCRIPTION
Made it so if a satellite group is active, then limit the selection to that group. In doing so, have limited the raycasting to the points. Will need to deal with the lines in another ticket.