### PR TITLE
fix: :bug: fixes an incorrect check for a string instead of regexp

### DIFF
--- a/src/viewer/SatelliteGroup.ts
+++ b/src/viewer/SatelliteGroup.ts
@@ -83,10 +83,12 @@ class SatelliteGroup {
    * @throws {Error} If nameRegex is not a string.
    */
   private searchNameRegex () {
-    if (typeof this.data !== 'string') {
-      throw new Error('nameRegex must be a string');
+    if (typeof this.data === 'string') {
+      throw new Error('nameRegex must be a RegExp');
     }
-    const regex = new RegExp(this.data);
+
+    // These are set as regular expressions in the config file.
+    const regex = this.data as RegExp;
     const satIdList = this.satelliteStore.searchNameRegex(regex);
     for (const satId of satIdList) {
       this.sats.push({


### PR DESCRIPTION
I previously thought we were looking for strings since we were converting them into regular expressions. It turns out we were passing in regular expressions and should have been typecasting them instead of creating new regular expressions out of the old ones.